### PR TITLE
feat: add DB schema for quizzes (closes #30)

### DIFF
--- a/RealYou/backend/supabase_migration.sql
+++ b/RealYou/backend/supabase_migration.sql
@@ -1,13 +1,16 @@
--- Users テーブル
+-- 1. users テーブル
 CREATE TABLE users (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  self_mbti VARCHAR(10),
-  baseline_caution INT NOT NULL CHECK (baseline_caution BETWEEN 0 AND 100),
-  baseline_calmness INT NOT NULL CHECK (baseline_calmness BETWEEN 0 AND 100),
-  baseline_logic INT NOT NULL CHECK (baseline_logic BETWEEN 0 AND 100),
-  baseline_coop INT NOT NULL CHECK (baseline_coop BETWEEN 0 AND 100),
-  baseline_positive INT NOT NULL CHECK (baseline_positive BETWEEN 0 AND 100),
-  created_at TIMESTAMP DEFAULT NOW()
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    auth_type TEXT NOT NULL DEFAULT 'dummy',
+    auth_payload JSONB DEFAULT '{}'::jsonb,
+    exp_web INTEGER NOT NULL DEFAULT 0,
+    exp_ai INTEGER NOT NULL DEFAULT 0,
+    exp_security INTEGER NOT NULL DEFAULT 0,
+    exp_infrastructure INTEGER NOT NULL DEFAULT 0,
+    exp_design INTEGER NOT NULL DEFAULT 0,
+    exp_game INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
 -- GameLogs テーブル
@@ -55,3 +58,37 @@ CREATE TABLE analysis_results (
 -- インデックス
 CREATE INDEX idx_game_logs_user_id ON game_logs(user_id);
 CREATE INDEX idx_game_logs_game_type ON game_logs(game_type);
+
+-- 2. quizzes テーブル
+CREATE TABLE quizzes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    title TEXT NOT NULL,
+    max_points INTEGER NOT NULL CHECK (max_points >= 10 AND max_points <= 100),
+    genres JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- 3. questions テーブル
+CREATE TABLE questions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    quiz_id UUID NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+    order_num INTEGER NOT NULL CHECK (order_num >= 1),
+    question_text TEXT NOT NULL,
+    options JSONB NOT NULL,
+    correct_index INTEGER NOT NULL CHECK (correct_index >= 0),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- 4. quiz_results テーブル
+CREATE TABLE quiz_results (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    quiz_id UUID NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+    correct_count INTEGER NOT NULL CHECK (correct_count >= 0),
+    total_questions INTEGER NOT NULL CHECK (total_questions > 0),
+    earned_points INTEGER NOT NULL CHECK (earned_points >= 0),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    CHECK (correct_count <= total_questions),
+    UNIQUE(user_id, quiz_id)
+);


### PR DESCRIPTION
## 概要
DBのスキーマ構築を実施し、プロジェクト最優先のインフラ基盤となるテーブルを作成。
closes #30

## 変更内容
- `users` テーブルのスキーマを最新の要件に合わせて更新
- クイズ機能に必要な以下の新規テーブルを追加
  - `quizzes` (クイズ本体の管理)
  - `questions` (クイズ内の各設問の管理)
  - `quiz_results` (ユーザーの基本スコア・実績管理)

## 考慮点・セキュリティ
デモ中の連打バグやデータ不整合を防ぐため、以下の制約をDBレベルで厳格に設定。
- **連打バグ防御:** `quiz_results` テーブルに `UNIQUE(user_id, quiz_id)` を付与
- **論理破綻の防止:** `CHECK` 等により、不正なスコアデータの混入を防止
- **カスケード制御:** `quizzes` (作成者依存) は `RESTRICT`、`questions` や `quiz_results` は `ON DELETE CASCADE` に設定し、安全なデータ削除ライフサイクルを構築

## レビュアーへの特記事項
過去のゲームAPIとの互換性を保つため、古いテーブル（`game_logs`, `analysis_results`）は削除してないです。
動作に支障はありませんが、将来的なリファクタリングで不要になれば削除してね。