### PR TITLE
fix:Talk-Scope 録音ボタンを押し直しても消えないように

### DIFF
--- a/TalkScope/Frontend/src/app/hooks/useSpeechRecognition.ts
+++ b/TalkScope/Frontend/src/app/hooks/useSpeechRecognition.ts
@@ -14,8 +14,18 @@ export const useSpeechRecognition = (): UseSpeechRecognitionReturn => {
   const [transcript, setTranscript] = useState('');
   const [isListening, setIsListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  
   const recognitionRef = useRef<any>(null);
   const listeningRef = useRef(false);
+
+  // 過去のセッションで「確定」したテキストを保持し続けるためのRef
+  const finalTranscriptRef = useRef('');
+
+  // 外部（App.tsxなど）から setTranscript が呼ばれた時にRefも同期する
+  const handleSetTranscript = useCallback((text: string) => {
+    finalTranscriptRef.current = text;
+    setTranscript(text);
+  }, []);
 
   useEffect(() => {
     const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
@@ -31,20 +41,28 @@ export const useSpeechRecognition = (): UseSpeechRecognitionReturn => {
     recognition.lang = 'ja-JP';
 
     recognition.onresult = (event: any) => {
-      let currentTranscript = '';
+      let interimTranscript = '';
+      let newlyFinalized = '';
 
-      for (let i = 0; i < event.results.length; i++) {
+      // 今回新しく認識された部分（resultIndex以降）だけをループする
+      for (let i = event.resultIndex; i < event.results.length; i++) {
         const text: string = event.results[i][0].transcript;
         const isFinal: boolean = event.results[i].isFinal;
 
-        // If it's a final result, it's a natural break
         if (isFinal) {
-          currentTranscript += text + '。\n';
+          newlyFinalized += text + '。\n';
         } else {
-          currentTranscript += text;
+          interimTranscript += text;
         }
       }
-      setTranscript(currentTranscript);
+
+      // 確定したテキストがあれば、蓄積用Refに追記する
+      if (newlyFinalized) {
+        finalTranscriptRef.current += newlyFinalized;
+      }
+
+      // 画面表示用には「過去の確定分 ＋ 今回の確定分 ＋ 認識途中のテキスト」をセット
+      setTranscript(finalTranscriptRef.current + interimTranscript);
     };
 
     recognition.onerror = (event: any) => {
@@ -89,12 +107,12 @@ export const useSpeechRecognition = (): UseSpeechRecognitionReturn => {
   }, []);
 
   const resetTranscript = useCallback(() => {
-    setTranscript('');
-  }, []);
+    handleSetTranscript('');
+  }, [handleSetTranscript]);
 
   return {
     transcript,
-    setTranscript,
+    setTranscript: handleSetTranscript, // ラップした関数を返す
     isListening,
     startListening,
     stopListening,


### PR DESCRIPTION
## 概要
音声認識（Web Speech API）を使用中、録音停止ボタンを押した後録音開始を押したり、無音が一定時間続くと、それまで文字起こしされたテキストがすべて消失してしまう不具合を修正しました。

## 原因
Web Speech APIの仕様により、無音が一定時間続くと自動的に認識セッションが終了し、再スタート時に結果の配列（`event.results`）が空に初期化されていました。
これまでの実装では、`onresult` イベント内で現在のセッションの認識結果だけを用いてState（`transcript`）を上書きしていたため、セッションが切り替わったタイミングで過去のテキストが消え去る状態になっていました。

## 変更内容
1. **確定済みテキストの永続化 (`finalTranscriptRef` の追加)**
   - セッションの切れ目やReactの再レンダリングの影響を受けずに、確定したテキスト（`isFinal === true`）を蓄積し続けるための `useRef` を導入しました。
2. **認識結果ループの最適化**
   - `onresult` 内での処理対象を `0` からではなく `event.resultIndex` から開始するように変更し、新しく認識された差分のみを正しく処理・追記するように修正しました。
3. **外部からの更新操作との同期 (`handleSetTranscript` の追加)**
   - アプリ側（`App.tsx`）からの「リセット」や「デモテキスト読み込み」などで `setTranscript` が呼ばれた際、画面のStateだけでなく内部の `finalTranscriptRef` も同時に更新・同期されるよう、ラッパー関数を作成してエクスポートするようにしました。

## 影響範囲
- `hooks/useSpeechRecognition.ts` の内部ロジック変更
- ※戻り値のインターフェースに変更はないため、呼び出し元（`App.tsx`）のコード修正は不要です。

## 動作確認手順
1. 音声認識（録音）を開始し、いくつか言葉を発して画面にテキストが表示されることを確認する。
2. そのまま数秒間（5秒程度）無音状態を作り、内部の認識セッションを自動再起動させる。
3. 再び言葉を発した際、過去のテキストが消えずに末尾へ正しく追記されることを確認する。
4. 「即時デモ」や「リセット」機能などの外部アクションを実行した際、テキストと内部データが正しく上書き・消去されることを確認する。