### PR TITLE
#62 復習送信の時間設定を反映させるように

### DIFF
--- a/MainMenu/script.js
+++ b/MainMenu/script.js
@@ -417,17 +417,58 @@ document.addEventListener('DOMContentLoaded', () => {
       tfSetBtn.addEventListener('click', () => {
           const formattedDate = tfDateInput.value;
           const h = tfHoursInput.value;
-          
-          tfStatusMsg.textContent = `OVERRIDE ACCEPTED: ${formattedDate} ${h}:00`;
-          tfStatusMsg.style.color = '#0ff';
-          
-          triggerFlash();
-          document.body.style.animation = 'terminalShake 0.4s';
-          setTimeout(() => document.body.style.animation = '', 400);
 
-          setTimeout(() => {
-              tfModal.classList.remove('active');
-          }, 1500);
+          console.log("取得した日付:", formattedDate);
+          console.log("取得した時間:", h);
+          
+          const hour24 = Number(h); // 時間を文字列から数値に変換
+
+          const today = new Date();
+          today.setHours(0, 0, 0, 0); // 時間をリセットして日付のみで比較
+          const targetDate = new Date(formattedDate);
+          targetDate.setHours(0, 0, 0, 0);
+          
+          const diffTime = targetDate.getTime() - today.getTime();
+          const daysAfter = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+          const payload = {
+              "days_after": daysAfter,
+              "hour_24": hour24
+          };
+          console.log("送信するデータ:", payload);
+
+          fetch('http://127.0.0.1:8000/api/config/review-delay', {
+              method: 'PUT',
+              headers: {
+                  'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(payload)
+          })
+          .then(response => {
+              if (!response.ok) {
+                  throw new Error(`HTTPエラー: ${response.status}`);
+              }
+              return response.json();
+          })
+          .then(data => {
+              console.log("API送信成功:", data);
+              
+              tfStatusMsg.textContent = `OVERRIDE ACCEPTED: ${formattedDate} ${h}:00`;
+              tfStatusMsg.style.color = '#0ff';
+              
+              triggerFlash();
+              document.body.style.animation = 'terminalShake 0.4s';
+              setTimeout(() => document.body.style.animation = '', 400);
+
+              setTimeout(() => {
+                  tfModal.classList.remove('active');
+              }, 1500);
+          })
+          .catch(error => {
+              console.error("API送信エラー:", error);
+              tfStatusMsg.textContent = `ERROR: CONNECTION FAILED`;
+              tfStatusMsg.style.color = '#f00';
+          });
       });
   }
 });

--- a/TimeFaker/Dockerfile
+++ b/TimeFaker/Dockerfile
@@ -17,4 +17,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # backendフォルダをルートとしてUvicornを起動
-CMD ["uvicorn", "main:app", "--app-dir", "backend", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--app-dir", "backend", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/TimeFaker/backend/main.py
+++ b/TimeFaker/backend/main.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 from fastapi import FastAPI, Depends, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy.orm import Session
 from contextlib import asynccontextmanager
@@ -329,7 +330,7 @@ async def lifespan(app: FastAPI):
     print("⏰ スケジューラーが起動しました")
 
     print("📡 BLEプロビジョニングサーバーを起動中...")
-    ble_task = asyncio.create_task(run_ble_server())
+    #ble_task = asyncio.create_task(run_ble_server())
     
     global button
     try:
@@ -343,12 +344,20 @@ async def lifespan(app: FastAPI):
     yield
     
     print("🛑 サーバー停止中。")
-    ble_task.cancel()
+    #ble_task.cancel()
 
 # ==========================
 # FastAPI アプリ定義
 # ==========================
 app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"], # フロントエンドのURLを許可
+    allow_credentials=True,
+    allow_methods=["*"], # GET, POST, PUT, DELETEなど全て許可
+    allow_headers=["*"],
+)
 
 def get_db():
     db = SessionLocal()


### PR DESCRIPTION
## 概要
フロントエンドの画面から復習通知の遅延設定（日数と時間）をバックエンドAPIに送信し、設定を上書きする機能を実装しました。
また、ローカルのDocker環境（Mac）でフロントエンドとバックエンドが正常に通信できるよう、CORS設定やコンテナの起動設定を修正しています。

## 変更内容
### 🎨 フロントエンド (JavaScript)
- `tfSetBtn` クリック時に、入力されたカレンダーの日付と現在日時の差分から `days_after`（何日後か）を自動計算する処理を追加。
- 計算した `days_after` と入力された `hour_24` をJSON形式にまとめ、`PUT /api/config/review-delay` へ送信する `fetch` 処理を実装。
- API通信成功時に、画面を揺らすアニメーションとステータス表示の更新を行い、モーダルを閉じるUI/UXを実装。

### ⚙️ バックエンド (FastAPI & Docker)
- **CORS対応**: `main.py` に `CORSMiddleware` を追加し、フロントエンド（`http://localhost:5173`）からのアクセスを許可。
- **コンテナ外部からのアクセス許可**: `Dockerfile` の起動コマンド（Uvicorn）で `--host 0.0.0.0` を明示的に指定し、コンテナ外からの通信を受け付けられるように修正。
- **ローカル開発環境のクラッシュ対策**: Mac上のDockerではBluetooth（BlueZ/D-Bus）デバイスが存在せずエラーで落ちてしまうため、`main.py` 内のBLEサーバー起動処理（`ble_task`）を一時的にコメントアウト。

## 動作確認手順
1. `docker compose up --build` でバックエンドを起動する。
2. フロントエンド（`localhost:5173`）を立ち上げる。
3. 画面上の設定モーダルから日付と時間を選択し、「OVERRIDE（設定）」ボタンを押す。
4. フロントエンドのコンソールに「API送信成功」と表示され、UIに反映されることを確認。
5. バックエンドのログで `PUT /api/config/review-delay` が `200 OK` で処理されたことを確認。

## 備考・注意点
- 現在、ローカル環境で立ち上げるために `main.py` の `run_ble_server()` をコメントアウトしています。ラズパイ（本番環境）にデプロイする際は、このコメントアウトを外す必要があります。