### PR TITLE
トクスコとリアルユの繋ぎ合わせ

### DIFF
--- a/TalkScope/Frontend/src/app/App.tsx
+++ b/TalkScope/Frontend/src/app/App.tsx
@@ -573,12 +573,14 @@ const App: React.FC = () => {
 
             try {
               // TODO: 実際のユーザーIDを取得するロジックに置き換えてください
-              const currentUserId = "123e4567-e89b-12d3-a456-426614174000";
+              const currentUserId =
+                localStorage.getItem("chimera_user_id") ||
+                "123e4567-e89b-12d3-a456-426614174000";
 
               // API呼び出し（awaitで完了を待つ）
               await sendFullTranscript({
-                user_id: currentUserId, // 修正: userId -> user_id
-                presentation_text: transcript, // 修正: transcript -> presentation_text
+                user_id: currentUserId,
+                presentation_text: transcript,
               });
 
               toast.success("🏁 発表を終了し、全文データを送信しました");


### PR DESCRIPTION
## 概要
TalkScope の「発表終了」操作をトリガーに、発表全文を RealYou Backend のクイズ生成 API へ送信する連携を実装しました。
これにより、発表内容をそのまま AI クイズ生成フローへ接続できます。

## 背景
これまで発表終了時の全文送信が API 仕様と接続されていなかった
クイズ生成 API は [user_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) と [presentation_text](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) を必須としているため、TalkScope 側で送信データ整備が必要だった

## 変更内容
* TalkScope 側
  * 発表終了ボタン押下時に API 送信を実行
  * 送信 payload を API 仕様に合わせて統一
    * [user_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    * [presentation_text](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)（全文）
  * [user_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) は [localStorage](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)（chimera_user_id）を優先して使用
* RealYou Backend 側
  * /api/quizzes/generate で受信時の確認ログを出力し、疎通確認を容易化
  * 既存バリデーション（UUID / text length）に沿って処理

## API 連携仕様
* Endpoint: POST /api/quizzes/generate
* Request Body:
  * [user_id: string (uuid)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  * [presentation_text: string (1..10000)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

## 動作確認
* TalkScope で録音/デモ後に「発表終了」を押す
* RealYou Backend 側で POST 到達ログが出ることを確認
* レスポンス 201 で [quiz_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) が返ることを確認
* [user_id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 不正・本文空などで 400 になることを確認

## 影響範囲
* TalkScope の発表終了フロー
* RealYou Backend のクイズ生成エンドポイント（受信ログのみ追加）

## 補足
* ローカル実行時はバックエンド起動状態と API URL 設定が必要です
* ERR_CONNECTION_REFUSED はサーバー未起動/到達不可時に発生します