### PR TITLE
各分野の得点を取得するAPI作成

### DIFF
--- a/RealYou/backend/src/routes/results.ts
+++ b/RealYou/backend/src/routes/results.ts
@@ -3,6 +3,17 @@ import { resultService } from '../services/resultService';
 
 const router = Router();
 
+router.get('/:user_id/total-exp', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.params.user_id as string;
+        const totalExp = await resultService.getTotalExp(userId);
+
+        res.json(totalExp);
+    } catch (error) {
+        next(error);
+    }
+});
+
 router.get('/:user_id', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const userId = req.params.user_id as string;

--- a/RealYou/backend/src/services/resultService.ts
+++ b/RealYou/backend/src/services/resultService.ts
@@ -7,6 +7,33 @@ import { getMbtiScores } from '../analysis/mbtiScoreTable';
 import { BaselineScores, ResultResponse } from '../types';
 
 export const resultService = {
+    async getTotalExp(userId: string): Promise<{
+        total_exp: {
+            web: number;
+            ai: number;
+            security: number;
+            infrastructure: number;
+            design: number;
+            game: number;
+        };
+    }> {
+        const user = await userRepository.findById(userId);
+        if (!user) {
+            throw { status: 404, code: 'user_not_found', message: 'User not found' };
+        }
+
+        return {
+            total_exp: {
+                web: user.exp_web ?? 0,
+                ai: user.exp_ai ?? 0,
+                security: user.exp_security ?? 0,
+                infrastructure: user.exp_infrastructure ?? 0,
+                design: user.exp_design ?? 0,
+                game: user.exp_game ?? 0,
+            },
+        };
+    },
+
     async getResult(userId: string): Promise<ResultResponse> {
         // ユーザー取得
         const user = await userRepository.findById(userId);

--- a/RealYou/backend/src/swagger.ts
+++ b/RealYou/backend/src/swagger.ts
@@ -242,6 +242,39 @@ export const swaggerDocument = {
         // =========================================================
         // Results  ← types/index.ts: ResultResponse
         // =========================================================
+        '/api/results/{user_id}/total-exp': {
+            get: {
+                tags: ['results'],
+                summary: '総経験値取得（GrowTree連携用）',
+                description: 'ユーザーの total_exp のみを返す軽量エンドポイント',
+                parameters: [
+                    {
+                        name: 'user_id',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'string', format: 'uuid' },
+                        example: '46f441c6-cc35-4bd3-ab49-953f5a287c83',
+                    },
+                ],
+                responses: {
+                    200: {
+                        description: '総経験値',
+                        content: {
+                            'application/json': {
+                                example: {
+                                    total_exp: { web: 60, ai: 0, security: 0, infrastructure: 0, design: 0, game: 0 },
+                                },
+                            },
+                        },
+                    },
+                    404: {
+                        description: 'ユーザーが存在しない',
+                        content: { 'application/json': { example: { status: 'error', code: 'user_not_found', message: 'User not found' } } },
+                    },
+                },
+            },
+        },
+
         '/api/results/{user_id}': {
             get: {
                 tags: ['results'],


### PR DESCRIPTION
## 概要
GrowTree 連携向けに、RealYou で「各分野の得点（総経験値）」のみを取得できる API を追加しました。  
既存の診断結果 API とは分離し、必要最小限のデータを返す軽量エンドポイントです。

## 変更内容
- `GET /api/results/{user_id}/total-exp` を新規追加
- レスポンスは `total_exp` のみを返却
  - `web`
  - `ai`
  - `security`
  - `infrastructure`
  - `design`
  - `game`
- ユーザー未存在時の 404 応答を追加
- Swagger/OpenAPI に新エンドポイント定義を追加

## 追加エンドポイント
### `GET /api/results/{user_id}/total-exp`

#### 200 OK
```json
{
  "total_exp": {
    "web": 60,
    "ai": 0,
    "security": 0,
    "infrastructure": 0,
    "design": 0,
    "game": 0
  }
}
```
#### 404 Not Found
```
{
  "status": "error",
  "code": "user_not_found",
  "message": "User not found"
}
```

## 目的
GrowTree が必要とするデータ（分野別経験値）のみを取得可能にする
既存の /api/results/{user_id} への依存を減らし、連携をシンプルにする
API 責務を明確化し、保守性を向上させる

## 動作確認
GET /api/results/{user_id}/total-exp で 200 が返る
 total_exp の6分野が返る
 存在しない user_id で 404 が返る
 Swagger にエンドポイントが表示される