### PR TITLE
RealYou: 問題一覧の「未回答」「満点以外」絞り込みUIを非表示化

### DIFF
--- a/RealYou/frontend/src/features/problem-list/components/ProblemListFlow.tsx
+++ b/RealYou/frontend/src/features/problem-list/components/ProblemListFlow.tsx
@@ -130,8 +130,9 @@ export default function ProblemListFlow() {
                 className="w-full appearance-none rounded-xl border-[3px] border-black bg-white px-3 py-2 pr-8 text-sm font-bold text-black shadow-[3px_3px_0_0_#000] focus:outline-none focus:ring-0 active:translate-y-0.5 active:shadow-[1px_1px_0_0_#000] transition-all"
               >
                 <option value="all">デフォルト</option>
+                {/* 完答稼働かの絞り込みUIを非表示 */}
                 <option value="unanswered">未回答</option>
-                <option value="not-perfect">満点以外</option>
+                {/* <option value="not-perfect">満点以外</option> */}
                 <option value="week">週指定</option>
               </select>
               <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-black">


### PR DESCRIPTION
**概要**
RealYouの問題リスト画面（[ProblemListFlow.tsx](cci:7://file:///Users/mikamiakihide/Project/WEB/58hack-team-kakinoha/RealYou/frontend/src/features/problem-list/components/ProblemListFlow.tsx:0:0-0:0)）において、問題の完答状況によるフィルタリング（「満点以外」）の選択肢をUI上から非表示にしました。

**変更点**
- [ProblemListFlow.tsx](cci:7://file:///Users/mikamiakihide/Project/WEB/58hack-team-kakinoha/RealYou/frontend/src/features/problem-list/components/ProblemListFlow.tsx:0:0-0:0) の表示絞り込み用 `<select>` 要素から、以下の `<option>` をコメントアウトして非表示化しました。
  - `not-perfect` (満点以外)
※ フィルタリングのロジック自体は保持したまま、UIからのアクセスのみを制限しています。

**影響範囲**
- `/problems` ページにおける問題の絞り込み機能

**確認項目**
- [x] 問題リスト画面のセレクトボックスから該当の項目が消えていること
- [x] 既存の「デフォルト」および「週指定」の絞り込みが正常に機能し、ビルドエラー等の他の影響が出ていないこと
